### PR TITLE
Fixes in tests.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/testDataset"]
+	path = tests/testDataset
+	url = https://github.com/implode-compression-impls/implode_test_files.git

--- a/pwexplode.py
+++ b/pwexplode.py
@@ -521,7 +521,7 @@ def explode(compressedstring):
                 decompresseddata += decompresseddata[sourcepos:sourcepos+1]
 
                 # Add to debug string
-                debug_string += decompresseddata[sourcepos:sourcepos+1].decode()
+                debug_string += repr(decompresseddata[sourcepos:sourcepos+1])
 
                 # Move forward
                 sourcepos += 1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import sys
+import unittest
+from collections import OrderedDict
+from pathlib import Path
+
+from fileTestSuite.unittest import FileTestSuiteTestCaseMixin
+
+dict = OrderedDict
+
+thisDir = Path(__file__).resolve().absolute().parent
+repoRootDir = thisDir.parent
+
+sys.path.insert(0, str(repoRootDir))
+
+from pwexplode import explode
+
+
+class Tests(unittest.TestCase, FileTestSuiteTestCaseMixin):
+    @property
+    def fileTestSuiteDir(self) -> Path:
+        return thisDir / "testDataset"
+
+    def _testProcessorImpl(self, challFile: Path, respFile: Path, paramsDict=None) -> None:
+        self.assertEqual(challFile.read_bytes(), explode(respFile.read_bytes()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed tests to use `unittest`.
Added more extensive test suite relying on my abstraction layer for tests. The abstraction layer is needed to share tests between different projects.
Minor changes in debug string generation, in order not to fail on binary inputs.

Some tests fail, but for my python bindings for `libblast` they pass. Not sure if it is me who should fix this implementation.